### PR TITLE
Increasing version of react-event-listener 

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,9 +1,8 @@
 import "./index.css";
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
-import { Main, Bar, Button } from "./ui";
+import { Main, Bar } from "./ui";
 import Popover from "react-text-selection-popover";
-import placeRightBelow from "react-text-selection-popover/lib/placeRightBelow";
 import Draggable from "react-draggable";
 
 class App extends Component {
@@ -19,7 +18,7 @@ class App extends Component {
 
   onChangeText = (e) => {
     console.log(e.target);
-  }
+  };
 
   render() {
     return (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-text-selection-popover",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "description": "A popover component positioned according to the current selection in a contenteditable element",
   "author": "juliankrispel",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "invariant": "2.2.4",
     "lodash.debounce": "4.0.8",
-    "react-event-listener": "0.6.1",
+    "react-event-listener": "0.6.6",
     "react-measure": "2.1.2",
     "react-window-dimensions": "1.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,7 +46,7 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/runtime@^7.0.0-beta.42":
+"@babel/runtime@^7.2.0":
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
   integrity sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==
@@ -6181,12 +6181,12 @@ react-error-overlay@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.1.tgz#417addb0814a90f3a7082eacba7cee588d00da89"
 
-react-event-listener@0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.6.1.tgz#41c7a80a66b398c27dd511e22712b02f3d4eccca"
-  integrity sha1-QceoCmazmMJ91RHiJxKwLz1OzMo=
+react-event-listener@0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.6.6.tgz#758f7b991cad9086dd39fd29fad72127e1d8962a"
+  integrity sha512-+hCNqfy7o9wvO6UgjqFmBzARJS7qrNoda0VqzvOuioEpoEXKutiKuv92dSz6kP7rYLmyHPyYNLesi5t/aH1gfw==
   dependencies:
-    "@babel/runtime" "^7.0.0-beta.42"
+    "@babel/runtime" "^7.2.0"
     prop-types "^15.6.0"
     warning "^4.0.1"
 


### PR DESCRIPTION
Currently, `react-event-listener` in version `0.6.1` is using `"@babel/runtime": "^7.0.0-beta.42"` that has some breaking changes in higher versions. This cause issues when I'm trying to use this component - error message below:
```
Module not found: 
Can't resolve '@babel/runtime/helpers/builtin/classCallCheck' 
in 'MyProject/node_modules/react-text-selection-popover/node_modules/react-event-listener/dist'
```

The core issue is probably located in `react-evenet-listener` in version `0.6.1` as `^` should not be used with dependencies in beta version based on [this SO thread](https://stackoverflow.com/questions/51686071/babel-js-file-cant-resolve-babel-runtime-helpers-builtin-classcallcheck)

Latest version of `react-event-listener` does not use beta version of `babel/runtime` so it should work correctly now. 

Also removing unused imports in example and increasing version of package to `1.2.4`.
