### PR TITLE
fix peer dependencies syntax to use `||` instead of `,`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "deploy": "npm run build:example && gh-pages -d build-site"
   },
   "peerDependencies": {
-    "react": "^16.8.0,^17.x,^18.x",
-    "react-dom": "^16.8.0,^17.x,^18.x"
+    "react": "^16.8.0 || ^17.x || ^18.x",
+    "react-dom": "^16.8.0 || ^17.x || ^18.x"
   },
   "devDependencies": {
     "@emotion/css": "^11.1.3",


### PR DESCRIPTION
Fix syntax error `npm error Invalid tag name "^16.8.0,^17.x,^18.x" of package "react@^16.8.0,^17.x,^18.x"`.

`npm` expects `||` for multiple version ranges, not `,`

> range1 || range2 Passes if either range1 or range2 are satisfied.
> Example: `"qux": "<1.0.0 || >=2.3.1 <2.4.5 || >=2.5.2 <3.0.0",`
Source: https://docs.npmjs.com/cli/v11/configuring-npm/package-json